### PR TITLE
Allow multiple borgmatic configuration files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apk upgrade --no-cache \
     && rm -rf /var/cache/apk/* \
     && chmod 755 /entry.sh
 VOLUME /config
+VOLUME /etc/borgmatic.d
 VOLUME /cache
 VOLUME /source
 VOLUME /repository

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ docker run -d \
   -v /mnt/borg:/repository \
   -v /home/user/.ssh:/root/.ssh \
   -v /srv/borgmatic/config:/config \
+  -v /srv/borgmatic/borgmatic.d:/etc/borgmatic.d/
   -v /srv/borgmatic/cache:/cache \
   b3vis/borgmatic
 ```
@@ -75,6 +76,7 @@ RUN apk upgrade --no-cache \
     && rm -rf /var/cache/apk/* \
     && chmod 755 /entry.sh
 VOLUME /config
+VOLUME /etc/borgmatic.d
 VOLUME /cache
 VOLUME /source
 VOLUME /repository

--- a/crontab.txt
+++ b/crontab.txt
@@ -1,1 +1,1 @@
-0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic -c /config/config.yaml  -v 1 2>&1
+0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic -v 1 2>&1


### PR DESCRIPTION
Borgmatic allows mutliple configuration files:
https://github.com/witten/borgmatic#multiple-configuration-files

Removed `-c` parameter and added a volume for `/etc/borgmatic.d` to store the configuration instead.
Borgmatic searches by default for configuration files in this directory.