### PR TITLE
Changed verbosity to warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Where you need to create crontab.txt and your borgmatic config.yml
 #### crontab.txt example
 In this file set the time you wish for your backups to take place default is 1am every day. In here you can add any other tasks you want ran
 ```
-0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic -c /config  -v 0 2>&1
+0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic -c /config  --stats -v 0 2>&1
 ```
 #### /cache
 A non volatile place to store the borg chunk cache

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Where you need to create crontab.txt and your borgmatic config.yml
 #### crontab.txt example
 In this file set the time you wish for your backups to take place default is 1am every day. In here you can add any other tasks you want ran
 ```
-0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic -c /config  -v 1 2>&1
+0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic -c /config  -v 0 2>&1
 ```
 #### /cache
 A non volatile place to store the borg chunk cache

--- a/crontab.txt
+++ b/crontab.txt
@@ -1,1 +1,1 @@
-0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic -v 0 2>&1
+0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1

--- a/crontab.txt
+++ b/crontab.txt
@@ -1,1 +1,1 @@
-0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic -v 1 2>&1
+0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic -v 0 2>&1


### PR DESCRIPTION
Borgmatic writes basically each file to standard out with verbosity = 1, therefore reduced to 0 (warn). In the past I don't remember seeing so many logs, so I suspect [this](https://github.com/witten/borgmatic/commit/7252b8d614456fa509453eca543190203b002528) change causing the the load.