### PR TITLE
Full utilization of .env

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,8 @@
+TZ=Europe/Berlin
 BORG_PASSPHRASE=ReplaceWithYourSecretPassPhrase
+VOLUME_SOURCE=/home
+VOLUME_TARGET=./data/repository
+VOLUME_ETC_BORGMATIC=./data/borgmatic.d
+VOLUME_BORG_CONFIG=./data/.config/borg
+VOLUME_SSH=./data/.ssh
+VOLUME_BORG_CACHE=./data/.cache/borg

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ data/.cache/
 data/.config/
 data/.ssh/
 data/repository/
-.envBORG_PASSPHRASE=ReplaceWithYourSecretPassPhrase
+.env

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ docker run \
   -v /home:/mnt/source:ro \
   -v /opt/docker/docker-borgmatic/data/repository:/mnt/repository \
   -v /opt/docker/docker-borgmatic/data/borgmatic.d:/etc/borgmatic.d/ \
-  -v /opt/docker/docker-borgmatic/data/.config:/root/.config/borg \
+  -v /opt/docker/docker-borgmatic/data/.config/borg:/root/.config/borg \
   -v /opt/docker/docker-borgmatic/data/.ssh:/root/.ssh \
-  -v /opt/docker/docker-borgmatic/data/.cache:/root/.cache/borg \
+  -v /opt/docker/docker-borgmatic/data/.cache/borg:/root/.cache/borg \
   -e TZ=Europe/Berlin \
   b3vis/borgmatic
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If using remote repositories mount your .ssh to /root/.ssh within the container.
 docker run \
   --detach --name borgmatic \
   -v /home:/mnt/source:ro \
-  -v /opt/docker/docker-borgmatic/data/repository:/mnt/repository \
+  -v /opt/docker/docker-borgmatic/data/repository:/mnt/borg-repository \
   -v /opt/docker/docker-borgmatic/data/borgmatic.d:/etc/borgmatic.d/ \
   -v /opt/docker/docker-borgmatic/data/.config/borg:/root/.config/borg \
   -v /opt/docker/docker-borgmatic/data/.ssh:/root/.ssh \
@@ -44,7 +44,7 @@ sh -c "borgmatic --init --encryption repokey-blake2"
 ### Layout
 #### /mnt/source
 Your data you wish to backup. For *some* safety you may want to mount read-only. Borgmatic is running as root so all files can be backed up. 
-#### /mnt/repository 
+#### /mnt/borg-repository
 Mount your borg backup repository here.
 #### /etc/borgmatic.d
 Where you need to create crontab.txt and your borgmatic config.yml
@@ -77,7 +77,7 @@ A non volatile place to store the borg chunk cache.
   - For backup restore: 
     1. Stop the backup container: `docker-compose down`
     2. Run an interactive shell: `docker-compose -f docker-compose.yml -f docker-compose.restore.yml run borgmatic`
-    3. Fuse-mount the backup: `borg mount /mnt/repository <mount_point>`
+    3. Fuse-mount the backup: `borg mount /mnt/borg-repository <mount_point>`
     4. Restore your files
     5. Finally unmount and exit: `borg umount <mount_point> && exit`.
   - In case Borg fails to create/acquire a lock: `borg break-lock /mnt/repository`

--- a/README.md
+++ b/README.md
@@ -71,9 +71,8 @@ A non volatile place to store the borg chunk cache.
 
 ### Docker Compose
   - To start the container for backup:
-    1. Set BORG_PASSPHRASE in .env
-    2. Adapt source/target in docker-compose.yml as needed
-    3. Run `docker-compose up -d`
+    1. Set BORG_PASSPHRASE and backup source/target in .env
+    2. Run `docker-compose up -d`
   - For backup restore: 
     1. Stop the backup container: `docker-compose down`
     2. Run an interactive shell: `docker-compose -f docker-compose.yml -f docker-compose.restore.yml run borgmatic`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It uses cron to run the backups at a time you can configure in `data/borgmatic.d
 
 To set your backup timing and configuration, you will need to create [crontab.txt](data/borgmatic.d/crontab.txt) and your borgmatic [config.yaml](data/borgmatic.d/config.yaml) and mount these files into the `/etc/borgmatic.d/` directory. When the container starts it creates the crontab from `crontab.txt` and starts crond. By cloning this repo in `/opt/docker/`, you will have a working setup to get started. 
 
-If using remote repositories mount your .ssh to /root/.ssh within the container
+If using remote repositories mount your .ssh to /root/.ssh within the container.
 
 ### Example run command
 ```
@@ -70,9 +70,10 @@ A non volatile place to store the borg chunk cache.
 - Repository passphrase, e.g. `BORG_PASSPHRASE="DonNotMissToChangeYourPassphrase"`
 
 ### Docker Compose
-  - To start the container for backup:
-    1. Set BORG_PASSPHRASE and backup source/target in .env
-    2. Run `docker-compose up -d`
+  - Prepare your configuration
+    1. `cp .env.template .env`
+    2. Set your environment and adapt volumes as needed
+  - To start the container for backup: `docker-compose up -d`
   - For backup restore: 
     1. Stop the backup container: `docker-compose down`
     2. Run an interactive shell: `docker-compose -f docker-compose.yml -f docker-compose.restore.yml run borgmatic`

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Where you need to create crontab.txt and your borgmatic config.yml
 - To generate an example borgmatic configuration, run:
 ```
 docker exec borgmatic \
-sh -c "generate-borgmatic-config -d /etc/borgmatic.d/config.yaml"
+sh -c "cd && generate-borgmatic-config -d /etc/borgmatic.d/config.yaml"
 ```
 - crontab.txt example: In this file set the time you wish for your backups to take place default is 1am every day. In here you can add any other tasks you want ran
 ```

--- a/data/borgmatic.d/config.yaml
+++ b/data/borgmatic.d/config.yaml
@@ -2,7 +2,7 @@ location:
     source_directories:
         - /mnt/source
     repositories:
-        - /mnt/repository
+        - /mnt/borg-repository
     one_file_system: true
 
 storage:

--- a/data/borgmatic.d/config.yaml
+++ b/data/borgmatic.d/config.yaml
@@ -6,7 +6,8 @@ location:
     one_file_system: true
 
 storage:
-    encryption_passphrase: "DonNotMissToChangeYourPassphrase"
+#   Passphase is set in varibable $BORG_PASSPHRASE
+#   encryption_passphrase: "DonNotMissToChangeYourPassphrase"
     compression: lz4
     archive_name_format: 'backup-{now}'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,12 @@ services:
     image: b3vis/borgmatic
     container_name: borgmatic
     volumes:
-      - '/home:/mnt/source:ro'                                            # backup source
-      - '/opt/docker/docker-borgmatic/data/repository:/mnt/repository'    # backup target
-      - '/opt/docker/docker-borgmatic/data/borgmatic.d:/etc/borgmatic.d/' # borgmatic config file(s) + crontab.txt
-      - '/opt/docker/docker-borgmatic/data/.config:/root/.config/borg'    # config and keyfiles
-      - '/opt/docker/docker-borgmatic/data/.ssh:/root/.ssh'               # ssh key for remote repositories
-      - '/opt/docker/docker-borgmatic/data/.cache:/root/.cache/borg'      # checksums used for deduplication
+      - ${VOLUME_SOURCE}:/mnt/source:ro           # backup source
+      - ${VOLUME_TARGET}:/mnt/repository          # backup target
+      - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/ # borgmatic config file(s) + crontab.txt
+      - ${VOLUME_BORG_CONFIG}:/root/.config/borg  # config and keyfiles
+      - ${VOLUME_SSH}:/root/.ssh                  # ssh key for remote repositories
+      - ${VOLUME_BORG_CACHE}:/root/.cache/borg    # checksums used for deduplication
     environment:
-      - TZ=Europe/Berlin
+      - TZ=${TZ}
+      - BORG_PASSPHRASE=${BORG_PASSPHRASE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     container_name: borgmatic
     volumes:
       - ${VOLUME_SOURCE}:/mnt/source:ro           # backup source
-      - ${VOLUME_TARGET}:/mnt/repository          # backup target
+      - ${VOLUME_TARGET}:/mnt/borg-repository     # backup target
       - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/ # borgmatic config file(s) + crontab.txt
       - ${VOLUME_BORG_CONFIG}:/root/.config/borg  # config and keyfiles
       - ${VOLUME_SSH}:/root/.ssh                  # ssh key for remote repositories


### PR DESCRIPTION
Moved all config parameter used in  docker-compose.yml to .env and did some minor fixes in README and .gitignore found during testing. This way setting borgmatic using docker-compose will require touching only .env file.