### PR TITLE
Add simple mta for relaying crontab output

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -6,3 +6,11 @@ VOLUME_ETC_BORGMATIC=./data/borgmatic.d
 VOLUME_BORG_CONFIG=./data/.config/borg
 VOLUME_SSH=./data/.ssh
 VOLUME_BORG_CACHE=./data/.cache/borg
+
+# Mail - example values
+MAILTO=log@example.com
+MAIL_RELAY_HOST=mail.example.com
+MAIL_PORT=587
+MAIL_FROM=pg_backup_rsynced
+MAIL_USER=log_mail
+MAIL_PASSWORD=

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,10 @@ RUN apk upgrade --no-cache \
     ca-certificates \
     lz4-libs \
     libacl \
+    msmtp \
     && rm -rf /var/cache/apk/* \
     && chmod 755 /entry.sh
+RUN ln -sf /usr/bin/msmtp /usr/sbin/sendmail
 VOLUME /mnt/source
 VOLUME /mnt/borg-repository
 VOLUME /etc/borgmatic.d

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ To set your backup timing and configuration, you will need to create [crontab.tx
 
 If using remote repositories mount your .ssh to /root/.ssh within the container.
 
+If you want to mail the results from cron:
+* Add your mail relay details to the [env file](.env.template) or mount your own [msmtprc](https://wiki.alpinelinux.org/wiki/Relay_email_to_gmail_(msmtp,_mailx,_sendmail) to `/etc/msmtprc`
+* Add add your mail address to crontag.txt e.g. `MAILTO=log@example.com`
+
 ### Example run command
 ```
 docker run \
@@ -60,7 +64,7 @@ sh -c "cd && generate-borgmatic-config -d /etc/borgmatic.d/config.yaml"
 0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1
 ```
 #### /root/.config/borg
-Here the borg config and keys for keyfile encryption modes are stored. Make sure to backup your keyfiles!
+Here the borg config and keys for keyfile encryption modes are stored. Make sure to backup your keyfiles! Also needed when encryption is set to none.
 #### /root/.ssh
 Mount either your own .ssh here or create a new one with ssh keys in for your remote repo locations.
 #### /root/.cache/borg
@@ -70,6 +74,12 @@ A non volatile place to store the borg chunk cache.
 - SSH parameters, e.g. `BORG_RSH="ssh -i /root/.ssh/id_ed25519 -p 50221"`
 - BORG_RSH="ssh -i /root/.ssh/id_ed25519 -p 50221"
 - Repository passphrase, e.g. `BORG_PASSPHRASE="DonNotMissToChangeYourPassphrase"`
+
+- Your mail relay host `MAIL_RELAY_HOST=mail.example.com`
+- Port of your mail relay `MAIL_PORT=587`
+- Username used to log in into your relay service `MAIL_USER=borgmatic_log@example.com`
+- Password for relay login   `MAIL_PASSWORD=SuperS3cretMailPw`
+- From part in your log mail `MAIL_FROM=borgmatic`
 
 ### Docker Compose
   - Prepare your configuration

--- a/data/borgmatic.d/crontab.txt
+++ b/data/borgmatic.d/crontab.txt
@@ -1,1 +1,3 @@
+MAILTO=""
+
 0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1

--- a/data/borgmatic.d/msmtprc.sh
+++ b/data/borgmatic.d/msmtprc.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+cat >/etc/msmtprc << EOF
+# Set default values for all following accounts.
+defaults
+auth           on
+tls            on
+tls_starttls	 on
+tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile		     /var/log/sendmail.log
+
+account	default
+host ${MAIL_RELAY_HOST}
+port ${MAIL_PORT}
+from ${MAIL_FROM}
+user ${MAIL_USER}
+password ${MAIL_PASSWORD}
+
+EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   borgmatic:
     image: b3vis/borgmatic
+    env_file: .env
     container_name: borgmatic
     volumes:
       - ${VOLUME_SOURCE}:/mnt/source:ro           # backup source

--- a/entry.sh
+++ b/entry.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+/bin/sh /etc/borgmatic.d/msmtprc.sh
+
 # Import your cron file
 /usr/bin/crontab /etc/borgmatic.d/crontab.txt
 # Start cron


### PR DESCRIPTION
Added the simple mail mta [msmtp](https://wiki.alpinelinux.org/wiki/Relay_email_to_gmail_(msmtp,_mailx,_sendmail ) to send crontab output via mail.

My idea was to get mail in case borgmatic is failing for some reason.

In case you want to change anything comment my pull request and I change it. Your borgmatic is great but I am just missing the mail feature. Thanks for your great container :)!