### PR TITLE
Add PostgreSQL client to support database dump hooks (#37).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN apk upgrade --no-cache \
 VOLUME /mnt/source
 VOLUME /mnt/borg-repository
 VOLUME /etc/borgmatic.d
+VOLUME /root/.borgmatic
 VOLUME /root/.config/borg
 VOLUME /root/.ssh
 VOLUME /root/.cache/borg

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest as builder
 MAINTAINER b3vis
 ARG BORG_VERSION=1.1.10
-ARG BORGMATIC_VERSION=1.3.14
+ARG BORGMATIC_VERSION=1.4.0
 RUN apk upgrade --no-cache \
     && apk add --no-cache \
     alpine-sdk \
@@ -30,6 +30,7 @@ RUN apk upgrade --no-cache \
     lz4-libs \
     libacl \
     msmtp \
+    postgresql-client \
     && ln -sf /usr/bin/msmtp /usr/sbin/sendmail \
     && rm -rf /var/cache/apk/* \
     && chmod 755 /entry.sh

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ docker run \
   -v /home:/mnt/source:ro \
   -v /opt/docker/docker-borgmatic/data/repository:/mnt/borg-repository \
   -v /opt/docker/docker-borgmatic/data/borgmatic.d:/etc/borgmatic.d/ \
+  -v /opt/docker/docker-borgmatic/data/.borgmatic:/root/.borgmatic \
   -v /opt/docker/docker-borgmatic/data/.config/borg:/root/.config/borg \
   -v /opt/docker/docker-borgmatic/data/.ssh:/root/.ssh \
   -v /opt/docker/docker-borgmatic/data/.cache/borg:/root/.cache/borg \
@@ -63,12 +64,14 @@ sh -c "cd && generate-borgmatic-config -d /etc/borgmatic.d/config.yaml"
 ```
 0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1
 ```
+#### /root/.borgmatic
+A non-volatile path for borgmatic to store database dumps. Only needed if you are using that feature.
 #### /root/.config/borg
 Here the borg config and keys for keyfile encryption modes are stored. Make sure to backup your keyfiles! Also needed when encryption is set to none.
 #### /root/.ssh
 Mount either your own .ssh here or create a new one with ssh keys in for your remote repo locations.
 #### /root/.cache/borg
-A non volatile place to store the borg chunk cache.
+A non-volatile place to store the borg chunk cache.
 ### Environment
 - Time zone, e.g. `TZ="Europe/Berlin"'`.
 - SSH parameters, e.g. `BORG_RSH="ssh -i /root/.ssh/id_ed25519 -p 50221"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - ${VOLUME_SOURCE}:/mnt/source:ro           # backup source
       - ${VOLUME_TARGET}:/mnt/borg-repository     # backup target
       - ${VOLUME_ETC_BORGMATIC}:/etc/borgmatic.d/ # borgmatic config file(s) + crontab.txt
+      - ${VOLUME_DOT_BORGMATIC}:/root/.borgmatic  # borgmatic database dumps
       - ${VOLUME_BORG_CONFIG}:/root/.config/borg  # config and keyfiles
       - ${VOLUME_SSH}:/root/.ssh                  # ssh key for remote repositories
       - ${VOLUME_BORG_CACHE}:/root/.cache/borg    # checksums used for deduplication


### PR DESCRIPTION
See #37 for more info.

Testing done: Built a Docker image with these changes, and ran it on an existing servers with two PostgreSQL 11.5 databases. I configured Borgmatic as follows:

```
hooks:
    postgresql_databases:
        - name: gitea
          hostname: gitea-database
          username: gitea
          password: redacted
        - name: mediagoblin
          hostname: mediagoblin-database
          username: mediagoblin
          password: redacted
```

Then I exec'd into the running Docker images and invoked backups manually, confirming that the dump files end up in the expected place in the created archive:

```
# borgmatic -v 2 create
...
A /root/.borgmatic/postgresql_databases/mediagoblin-database/mediagoblin                                                                         
A /root/.borgmatic/postgresql_databases/gitea-database/gitea   
...
```

Also confirmed the same thing via `borgmatic list`:

```
# borgmatic list --archive apps-2019-10-24T19:19:46.062333 2>&1 | grep postgresql_databases
drwxr-xr-x root   root          0 Thu, 2019-10-24 19:18:08 root/.borgmatic/postgresql_databases
drwx------ root   root          0 Thu, 2019-10-24 19:18:08 root/.borgmatic/postgresql_databases/mediagoblin-database
-rw-r--r-- root   root     531390 Thu, 2019-10-24 19:18:08 root/.borgmatic/postgresql_databases/mediagoblin-database/mediagoblin
drwx------ root   root          0 Thu, 2019-10-24 19:15:58 root/.borgmatic/postgresql_databases/gitea-database
-rw-r--r-- root   root     905987 Thu, 2019-10-24 19:18:08 root/.borgmatic/postgresql_databases/gitea-database/gitea
```

Compressed image size increase: From 34.62 MB before this change to 37.79 MB after this change.