### PR TITLE
Fixed regression that logs no longer work

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ If using remote repositories mount your .ssh to /root/.ssh within the container.
 If you want to mail the results from cron:
 * Add your mail relay details to the [env file](.env.template) or mount your own [msmtprc](https://wiki.alpinelinux.org/wiki/Relay_email_to_gmail_(msmtp,_mailx,_sendmail) to `/etc/msmtprc`
 * Add add your mail address to crontag.txt and uncomment the line, e.g. `MAILTO=log@example.com`
+* Please note that logs will no longer end up in Docker logs when MAILTO is set.
 
 ### Example run command
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If using remote repositories mount your .ssh to /root/.ssh within the container.
 
 If you want to mail the results from cron:
 * Add your mail relay details to the [env file](.env.template) or mount your own [msmtprc](https://wiki.alpinelinux.org/wiki/Relay_email_to_gmail_(msmtp,_mailx,_sendmail) to `/etc/msmtprc`
-* Add add your mail address to crontag.txt e.g. `MAILTO=log@example.com`
+* Add add your mail address to crontag.txt and uncomment the line, e.g. `MAILTO=log@example.com`
 
 ### Example run command
 ```

--- a/data/borgmatic.d/crontab.txt
+++ b/data/borgmatic.d/crontab.txt
@@ -1,3 +1,3 @@
-MAILTO=""
+#MAILTO=log@example.com
 
 0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1


### PR DESCRIPTION
The MAILTO="" in crontab  suppresses output in the docker logs.