### PR TITLE
Upgrade borgmatic to 1.4.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest as builder
 MAINTAINER b3vis
 ARG BORG_VERSION=1.1.10
-ARG BORGMATIC_VERSION=1.4.0
+ARG BORGMATIC_VERSION=1.4.21
 RUN apk upgrade --no-cache \
     && apk add --no-cache \
     alpine-sdk \

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ VOLUME /root/.borgmatic
 VOLUME /root/.config/borg
 VOLUME /root/.ssh
 VOLUME /root/.cache/borg
-COPY --from=builder /usr/lib/python3.7/site-packages /usr/lib/python3.7/
+COPY --from=builder /usr/lib/python3.8/site-packages /usr/lib/python3.8/
 COPY --from=builder /usr/bin/borg /usr/bin/
 COPY --from=builder /usr/bin/borgfs /usr/bin/
 COPY --from=builder /usr/bin/borgmatic /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apk upgrade --no-cache \
     libacl \
     msmtp \
     postgresql-client \
+    mariadb-client \
     && ln -sf /usr/bin/msmtp /usr/sbin/sendmail \
     && rm -rf /var/cache/apk/* \
     && chmod 755 /entry.sh


### PR DESCRIPTION
Borgmatic has received numerous bug fixes and improvements since 1.4.0, among others the ability to backup MySQL databases and improved monitoring.