### PR TITLE
Update borg to 1.1.13 and borgmatic to 1.5.8

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:latest as builder
-MAINTAINER b3vis
-ARG BORG_VERSION=1.1.11
-ARG BORGMATIC_VERSION=1.5.1
+LABEL mainainer='b3vis'
+ARG BORG_VERSION=1.1.13
+ARG BORGMATIC_VERSION=1.5.8
 RUN apk upgrade --no-cache \
     && apk add --no-cache \
     alpine-sdk \
@@ -18,7 +18,7 @@ RUN apk upgrade --no-cache \
     && pip3 install --upgrade llfuse
 
 FROM alpine:latest
-MAINTAINER b3vis
+LABEL mainainer='b3vis'
 COPY entry.sh /entry.sh
 RUN apk upgrade --no-cache \
     && apk add --no-cache \

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,6 +6,7 @@ RUN apk upgrade --no-cache \
     && apk add --no-cache \
     alpine-sdk \
     python3-dev \
+    py3-pip \
     openssl-dev \
     lz4-dev \
     acl-dev \


### PR DESCRIPTION
* Update borg to 1.1.13 and borgmatic to 1.5.8
* Replace deprecated `MAINTAINER` to recommended `LABEL maintainer=`
* Fix missing py3-pip package in builder (https://github.com/b3vis/docker-borgmatic/issues/51)