### PR TITLE
Remove redundant MAILTO from msmtp.env.template

### DIFF
--- a/msmtp/README.md
+++ b/msmtp/README.md
@@ -10,7 +10,7 @@ For general usage instuctions see the [README](../base/README.md) of the base im
 
 If you want to mail the results from cron:
 * Add your mail relay details to the [msmtp.env](msmtp.env.template) or mount your own [msmtprc](https://wiki.alpinelinux.org/wiki/Relay_email_to_gmail_(msmtp,_mailx,_sendmail) to `/etc/msmtprc`
-* Add your mail address to crontag.txt and uncomment the line, e.g. `MAILTO=log@example.com`
+* Add your mail address to crontab.txt by editing the line `MAILTO=log@example.com`
 * Please note that logs will no longer end up in Docker logs when MAILTO is set.
 
 ### Environment

--- a/msmtp/data/borgmatic.d/crontab.txt
+++ b/msmtp/data/borgmatic.d/crontab.txt
@@ -1,3 +1,5 @@
-#MAILTO=log@example.com
+# Set MAILTO, to send crontab output to mail (Instead of docker logs)
+# Comma separate multiple addresses, do not use spaces or quotes
+MAILTO=log@example.com
 
 0 1 * * * PATH=$PATH:/usr/bin /usr/bin/borgmatic --stats -v 0 2>&1

--- a/msmtp/msmtp.env.template
+++ b/msmtp/msmtp.env.template
@@ -1,5 +1,4 @@
 # Mail - example values
-MAILTO=log@example.com
 MAIL_RELAY_HOST=mail.example.com
 MAIL_PORT=587
 MAIL_FROM=pg_backup_rsynced


### PR DESCRIPTION
Please double-check this, as I don't want to break anything.
That being said, I think this is redundant as MAILTO must be set in crontab anyway. 

Changing this MAILTO had no effect on the mail recipients and email notifications worked if I removed MAILTO from the container environment variables completely.