### PR TITLE
Fix build error

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,8 +1,8 @@
-FROM alpine:latest as builder
+FROM alpine:3.13 as builder
 LABEL mainainer='b3vis'
 ARG BORG_VERSION=1.1.16
 ARG BORGMATIC_VERSION=1.5.14
-ARG LLFUSE_VERSION=1.3.6
+ARG LLFUSE_VERSION=1.3.8
 RUN apk upgrade --no-cache \
     && apk add --no-cache \
     alpine-sdk \
@@ -20,7 +20,7 @@ RUN apk upgrade --no-cache \
     && pip3 install --upgrade borgmatic==${BORGMATIC_VERSION} \
     && pip3 install --upgrade llfuse==${LLFUSE_VERSION}
 
-FROM alpine:latest
+FROM alpine:3.13
 LABEL mainainer='b3vis'
 COPY entry.sh /entry.sh
 RUN apk upgrade --no-cache \

--- a/ntfy/Dockerfile
+++ b/ntfy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as builder
+FROM alpine:3.13 as builder
 LABEL mainainer='b3vis'
 RUN apk upgrade --no-cache \
     && apk add --no-cache \


### PR DESCRIPTION
fix alpine:3.13 - latest version has python3.9 which this repo is not ready for
fix LLFUSE_VERSION=1.3.8 - llfuse does not build with latest alpine image